### PR TITLE
Feat/Refactor: Implicit sudo in installer script, installer test cases & Actions workflow

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -57,14 +57,37 @@ jobs:
       - name: Build Cloudlift Package
         run: python scripts/build.py --os ${{ matrix.build_os }}
 
-      - name: Archive Artifact
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: "${{ env.package_name }}"
           path: "/tmp/${{ env.package_name }}.tar.gz"
 
-  test:
+  add_checksums:
     needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: "${{ github.workspace }}/artifacts"
+
+      - name: Generate Checksums
+        run: |
+          find "${{ github.workspace }}/artifacts" -type f -name "*.tar.gz" | while read -r file; do
+              sha=$(sha256sum "$file" | cut -d' ' -f1)
+              echo "$(basename "$file"): $sha" >> ${{ github.workspace }}/checksums.txt
+          done
+
+      - name: Upload Checksums
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksums
+          path: ${{ github.workspace }}/checksums.txt
+
+  test:
+    needs: add_checksums
     strategy:
       matrix:
         include:
@@ -102,6 +125,42 @@ jobs:
         run: |
           python scripts/build.py --os ${{ matrix.build_os }}  --only-test --package-dir ${{ github.workspace }}/artifacts/${{ env.package_name }}
 
+  test_installer:
+    needs: add_checksums
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+          - os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: "${{ github.workspace }}/artifacts"
+
+
+      - name: Test Installer
+        run: |
+          installer_test_path=/tmp/installer-test
+          installer_test_artifacts_path=$installer_test_path/${{ github.ref_name }}
+          mkdir -p $installer_test_path
+          mkdir -p $installer_test_artifacts_path
+          find ./artifacts -name '*.tar.gz' -exec mv {} $installer_test_artifacts_path \;
+          find ./artifacts -name 'checksums.txt' -exec mv {} $installer_test_artifacts_path \;
+          cp -r scripts/* /tmp/installer-test
+          cd /tmp/installer-test
+          bash test_installer.sh ${{ github.ref_name }} 
+
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -119,20 +178,13 @@ jobs:
         with:
           path: "${{ github.workspace }}/artifacts"
 
-      - name: Calculate SHA of Packages
-        run: |
-          find "${{ github.workspace }}/artifacts" -type f -name "*.tar.gz" | while read -r file; do
-              sha=$(sha256sum "$file" | cut -d' ' -f1)
-              echo "$(basename "$file"): $sha" >> checksums.txt
-          done
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             ${{ github.workspace }}/artifacts/**/*.tar.gz
-            checksums.txt
+            ${{ github.workspace }}/artifacts/checksums/checksums.txt
           tag_name: ${{ env.tag }}
           name: "Release ${{ env.tag }}"
           draft: false

--- a/scripts/test_installer.sh
+++ b/scripts/test_installer.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cleanup() {
+    echo "Cleaning up..."
+    kill $SERVER_PID 2>/dev/null || true
+}
+
+current_tag="$1"
+if [ -z "$current_tag" ]; then
+    echo "Error: No tag provided" >&2
+    exit 1
+fi
+echo "Current tag: $current_tag"
+
+# Get the current tag
+# current_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+
+create_mock_files() {
+    # Create JSON response to mock GitHub's release API endpoint
+    echo "{\"tag_name\":\"$current_tag\"}" > release_api_res.json
+}
+
+start_server() {
+    python3 -m http.server 3000 &
+    SERVER_PID=$!
+    echo "Server started with PID: $SERVER_PID"
+
+    # Wait for the server to start
+    while ! curl -s http://localhost:3000 > /dev/null; do
+        sleep 1
+    done
+}
+
+run_installer() {
+    # Run installer with given arguments
+    local input="$1"
+    shift
+    echo "$input" | sudo -E ./installer.sh "$@" 2>&1
+}
+
+test_fresh_install() {
+    echo "Testing fresh installation..."
+    run_installer "y"
+    current_tag_without_v="${current_tag#v}" 
+    cloudlift --version
+    if cloudlift --version | grep -q $current_tag_without_v; then
+        echo "Fresh install test passed"
+    else
+        echo "Fresh install test failed"
+        return 1
+    fi
+}
+
+test_reinstall() {
+    echo "Testing reinstallation..."
+    run_installer "y"
+    current_tag_without_v="${current_tag#v}" 
+    if sudo cloudlift --version | grep -q $current_tag_without_v; then
+        echo "Reinstall test passed"
+    else
+        echo "Reinstall test failed"
+        return 1
+    fi
+}
+
+test_specific_version() {
+    echo "Testing installation of specific version..."
+    current_tag_without_v="${current_tag#v}"
+    run_installer "y" "-v" $current_tag_without_v
+    if cloudlift --version | grep -q $current_tag_without_v; then
+        echo "Specific version install test passed"
+    else
+        echo "Specific version install test failed"
+        return 1
+    fi
+}
+
+test_uninstall() {
+    echo "Testing uninstallation..."
+    output=$(run_installer "y" "-u" 2>&1)
+    # echo "$output" 
+    if echo "$output" | grep -q "Cloudlift package uninstalled successfully"; then
+        if which cloudlift &> /dev/null; then
+            echo "Uninstall test failed: cloudlift command still exists"
+            return 1
+        else
+            echo "Uninstall test passed"
+        fi
+    else
+        echo "Uninstall test failed: uninstallation message not found"
+        return 1
+    fi
+}
+
+test_auto_approve() {
+    echo "Testing auto-approve installation..."
+    output=$(sudo -E ./installer.sh -y 2>&1)
+    echo "Installer output:"
+    echo "$output"
+    
+    if echo "$output" | grep -q "Cloudlift package installed successfully"; then
+        installed_version=$(sudo cloudlift --version | cut -d' ' -f3)
+        echo "Installed Cloudlift version: $installed_version"
+        echo "Current tag: $current_tag"
+        
+        if [ -n "$installed_version" ]; then
+            echo "Auto-approve install test passed"
+        else
+            echo "Auto-approve install test failed: Could not detect installed version"
+            return 1
+        fi
+    else
+        echo "Auto-approve install test failed: Installation was not successful"
+        return 1
+    fi
+}
+
+main() {
+    create_mock_files
+    start_server
+
+    export CLOUDLIFT_LATEST_RELEASE_URL="http://localhost:3000/release_api_res.json"
+    export CLOUDLIFT_DOWNLOAD_BASE_URL="http://localhost:3000"
+
+    test_fresh_install
+    test_reinstall
+    test_specific_version
+    test_uninstall
+    test_auto_approve
+
+    echo "All tests completed."
+}
+
+main


### PR DESCRIPTION
This PR contains changes to make `sudo` implicit in `installer.sh`. This will be helpful when one copies the installer snippet from readme, they don't need to explicitly prepend `sudo` to the snippet. This would auto handle existing `sudo` privileges, also if the user is already a root.

PR also containers test cases to test the installer script. Refactored the `Release packages` workflow to add the installer testing jobs, also refactored and added a dedicated job to generate checksum/digest of the artifacts generated. 